### PR TITLE
⚡️ Add `validate_openai_dataset`, & use `.cache` to store training files

### DIFF
--- a/src/opentrain/__init__.py
+++ b/src/opentrain/__init__.py
@@ -1,4 +1,4 @@
 """`opentrain `: 🚂 Fine-tune OpenAI models for text classification, question answering, and more"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@gmail.com>"
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/src/opentrain/train.py
+++ b/src/opentrain/train.py
@@ -1,9 +1,10 @@
-import json
 import warnings
 from pathlib import Path
 from typing import Union
 
 import openai
+
+from opentrain.utils import prepare_openai_dataset
 
 
 class OpenAITrainer:
@@ -53,7 +54,7 @@ class OpenAITrainer:
             The fine-tune ID.
         """
         if isinstance(path_or_buf, list):
-            file_path = self._prepare_training_data(path_or_buf)
+            file_path = prepare_openai_dataset(path_or_buf)
         elif isinstance(path_or_buf, Path):
             file_path = path_or_buf.as_posix()
         else:
@@ -91,19 +92,3 @@ class OpenAITrainer:
         if not self.fine_tune_id:
             raise ValueError("You must first train the model.")
         return openai.FineTune.stream_events(self.fine_tune_id)
-
-    def _prepare_training_data(self, buf: list) -> str:
-        """Prepare the training data for OpenAI, and save it to a JSONL file.
-
-        Args:
-            buf: A list of dictionaries containing the training data.
-
-        Returns:
-            The path to the JSONL file.
-        """
-        file_path = Path.cwd() / "training_data.jsonl"
-        with open(file_path, "w") as f:
-            for entry in buf:
-                json.dump(entry, f)
-                f.write("\n")
-        return file_path.as_posix()

--- a/src/opentrain/train.py
+++ b/src/opentrain/train.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import openai
 
-from opentrain.utils import prepare_openai_dataset
+from opentrain.utils import prepare_openai_dataset, validate_openai_dataset
 
 
 class OpenAITrainer:
@@ -59,6 +59,11 @@ class OpenAITrainer:
             file_path = path_or_buf.as_posix()
         else:
             file_path = path_or_buf
+
+        assert validate_openai_dataset(file_path), (
+            "The dataset is not valid, since it must contain only prompt-completion"
+            " pairs."
+        )
 
         upload_response = openai.File.create(
             file=open(file_path, "rb"),

--- a/src/opentrain/utils.py
+++ b/src/opentrain/utils.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from typing import List
 
 import openai
@@ -20,3 +22,23 @@ def list_fine_tunes(just_succeeded: bool = True) -> List[str]:
             if fine_tune["status"] == "succeeded"
         ]
     return [fine_tune["fine_tuned_model"] for fine_tune in fine_tunes]
+
+
+def prepare_openai_dataset(data: list) -> str:
+    """Prepare the training data for OpenAI, and save it to a JSONL file.
+
+    Args:
+        data: A list of dictionaries containing the training data, which MUST be
+            formatted as prompt-completion pairs.
+
+    Returns:
+        The path to the JSONL file.
+    """
+    file_path = Path.cwd() / str(uuid4()) / "training_data.jsonl"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w") as f:
+        for entry in data:
+            json.dump(entry, f)
+            f.write("\n")
+    return file_path.as_posix()
+

--- a/src/opentrain/utils.py
+++ b/src/opentrain/utils.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Union
 from uuid import uuid4
 
 import openai
@@ -25,26 +25,33 @@ def list_fine_tunes(just_succeeded: bool = True) -> List[str]:
     return [fine_tune["fine_tuned_model"] for fine_tune in fine_tunes]
 
 
-def prepare_openai_dataset(data: list) -> str:
+def prepare_openai_dataset(
+    data: list, output_path: Union[str, Path, None] = None
+) -> str:
     """Prepare the training data for OpenAI, and save it to a JSONL file.
 
     Args:
         data: A list of dictionaries containing the training data, which MUST be
             formatted as prompt-completion pairs.
+        output_path: The path to the JSONL file. Defaults to None, which means that
+            the $HOME/.cache will be used instead.
 
     Returns:
         The path to the JSONL file.
     """
-    file_path = Path.cwd() / str(uuid4()) / "training_data.jsonl"
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(file_path, "w") as f:
+    if output_path is None:
+        output_path = Path.home() / ".cache" / "opentrain" / f"{uuid4()}.jsonl"
+    if not isinstance(output_path, Path):
+        output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
         for entry in data:
             json.dump(entry, f)
             f.write("\n")
-    return file_path.as_posix()
+    return output_path.as_posix()
 
 
-def validate_openai_dataset(file_path: str) -> bool:
+def validate_openai_dataset(file_path: Union[str, Path]) -> bool:
     """Validate the training data for OpenAI.
 
     Args:
@@ -53,12 +60,14 @@ def validate_openai_dataset(file_path: str) -> bool:
     Returns:
         True if the training data is valid, False otherwise.
     """
+    if isinstance(file_path, Path):
+        file_path = file_path.as_posix()
     with open(file_path, "r") as f:
         for line in f:
             try:
                 json_line = json.loads(line)
-            except json.JSONDecodeError:
-                raise ValueError(f"Line {line} is not a JSON object.")
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Line {line} is not a JSON object.") from e
             if not ["prompt", "completion"] == list(json_line.keys()):
                 return False
     return True

--- a/src/opentrain/utils.py
+++ b/src/opentrain/utils.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from typing import List
+from uuid import uuid4
 
 import openai
 
@@ -42,3 +43,22 @@ def prepare_openai_dataset(data: list) -> str:
             f.write("\n")
     return file_path.as_posix()
 
+
+def validate_openai_dataset(file_path: str) -> bool:
+    """Validate the training data for OpenAI.
+
+    Args:
+        file_path: The path to the training data.
+
+    Returns:
+        True if the training data is valid, False otherwise.
+    """
+    with open(file_path, "r") as f:
+        for line in f:
+            try:
+                json_line = json.loads(line)
+            except json.JSONDecodeError:
+                raise ValueError(f"Line {line} is not a JSON object.")
+            if not ["prompt", "completion"] == list(json_line.keys()):
+                return False
+    return True


### PR DESCRIPTION
## ✨ Features

- Move `prepare_openai_dataset` to `utils.py`
- Add `validate_openai_dataset` to `utils.py`
- Allow `pathlib.Path` instead of just `str` when calling `train` and the subsequent methods

## 🐛 Bug Fixes

- Store training files in cache at `$HOME/.cache/opentrain/<UUID4>.jsonl` to avoid overwriting the same file over and over

## 🧪 Tests

- [ ] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.