### PR TITLE
🍱 Add schema-validation for OpenAI datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ docs = [
   "mkdocs-git-revision-date-localized-plugin~=1.1.0",
   "mkdocstrings[python]~=0.19.0",
 ]
+pydantic = ["pydantic>=1.10,<2"]
 quality = [
   "black~=22.10.0",
   "ruff~=0.0.194",

--- a/src/opentrain/schemas.py
+++ b/src/opentrain/schemas.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+try:
+    from pydantic import BaseModel
+
+    has_pydantic = True
+except ImportError:
+    has_pydantic = False
+
+if has_pydantic:
+
+    class PromptCompletion(BaseModel):
+        prompt: str
+        completion: str
+
+else:
+
+    @dataclass
+    class PromptCompletion:
+        prompt: str
+        completion: str

--- a/src/opentrain/utils.py
+++ b/src/opentrain/utils.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 
 import openai
 
+from opentrain.schemas import PromptCompletion
+
 
 def list_fine_tunes(just_succeeded: bool = True) -> List[str]:
     """List all fine-tuned models in your OpenAI account.
@@ -63,11 +65,11 @@ def validate_openai_dataset(file_path: Union[str, Path]) -> bool:
     if isinstance(file_path, Path):
         file_path = file_path.as_posix()
     with open(file_path, "r") as f:
-        for line in f:
+        for line in f.readlines():
             try:
-                json_line = json.loads(line)
+                PromptCompletion(**json.loads(line))
             except json.JSONDecodeError as e:
                 raise ValueError(f"Line {line} is not a JSON object.") from e
-            if not ["prompt", "completion"] == list(json_line.keys()):
-                return False
+            except Exception as e:
+                raise ValueError(f"Line {line} is not a prompt-completion pair.") from e
     return True


### PR DESCRIPTION
## ✨ Features

- Add `PromptCompletion` schema with both `dataclasses` by default, or with `pydantic` if available (included as an extra dependency)
- Add `PromptCompletion` validation in `validate_openai_dataset`

## ➖ Minor

* Remove Python 3.11 from `trove-classifiers` since not actively supported

## 🧪 Tests

- [X] Add integration tests in `test_schemas` to make sure the validation is working as expected, besides the `validate_openai_dataset` unit tests.