### PR TITLE
⬆️ Bump version from `0.0.3` to `0.0.4`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.194"
+    rev: "v0.0.263"
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
 pydantic = ["pydantic>=1.10,<2"]
 quality = [
   "black~=22.10.0",
-  "ruff~=0.0.194",
+  "ruff~=0.0.263",
   "pre-commit~=2.20.0",
 ]
 tests = [

--- a/src/opentrain/__init__.py
+++ b/src/opentrain/__init__.py
@@ -1,4 +1,4 @@
 """`opentrain `: 🚂 Fine-tune OpenAI models for text classification, question answering, and more"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@gmail.com>"
-__version__ = "0.0.3"
+__version__ = "0.0.4"


### PR DESCRIPTION
## 🔖 Versioning

- Upgrade `opentrain` from `0.0.3` to `0.0.4`

## ⬆️ Dependencies

- Upgrade `ruff` to use latest version ([`v0.0.263`](https://github.com/charliermarsh/ruff/releases/tag/v0.0.263) as of today)