### PR TITLE
✨ Add `Dataset` class to manage OpenAI Files ("Datasets")

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: check-quality
         run: |
-          ruff src tests
           black --check --diff --preview src tests
+          ruff src tests
 
   run-tests:
     needs: check-quality

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -1,0 +1,9 @@
+# 🔮 v0.2.0 - TODOs
+
+- [ ] Add `Typer` CLI e.g. `opentrain train ...`
+- [ ] Add `Dataset` validation before actually uploading a `Dataset`/`File` to OpenAI.
+- [ ] Add `Dataset.from_datasets`, `Dataset.to_datasets`, and `Dataset.to_records`.
+- [ ] Add `fsspec` support for `Dataset.from_file`, and `Dataset.to_file`.
+- [ ] Allow different input paths such as `pathlib.Path` or `os.path` in `Dataset.from_file`.
+- [ ] Explore https://github.com/openai/openai-python/blob/c556584eff3b36c92278e6af62cfe02ebb68fb65/openai/api_resources/file.py#L218 to avoid uploading duplicated files to OpenAI.
+- [ ] Add `Trainer.for_text_classification`, `Trainer.for_question_answering`, and more if applicable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,4 +50,5 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - Warning: warning.md
+  - TODOs: todos.md
   - License: license.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,4 +48,6 @@ extra:
 
 nav:
   - Home: index.md
+  - Usage: usage.md
+  - Warning: warning.md
   - License: license.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,12 @@ features = [
 
 [tool.hatch.envs.quality.scripts]
 check = [
-  "ruff src tests",
   "black --check --diff --preview src tests",
+  "ruff src tests",
 ]
 style = [
-  "ruff --fix src tests",
   "black --preview src tests",
+  "ruff --fix src tests",
   "check",
 ]
 

--- a/src/opentrain/__init__.py
+++ b/src/opentrain/__init__.py
@@ -2,3 +2,7 @@
 
 __author__ = "Alvaro Bartolome <alvarobartt@gmail.com>"
 __version__ = "0.1.0"
+
+from opentrain.dataset import Dataset, File, list_datasets, list_files
+
+__all__ = ["Dataset", "File", "list_datasets", "list_files"]

--- a/src/opentrain/dataset.py
+++ b/src/opentrain/dataset.py
@@ -13,15 +13,51 @@ FILE_SIZE_WARNING = 500 * 1024 * 1024
 
 
 class Dataset:
+    """The `Dataset` class is not just a wrapper around OpenAI's File API, but it also
+    provides some useful methods to work with datasets.
+
+    Args:
+        file_id: the ID of the file previously uploaded to OpenAI.
+        organization: the OpenAI organization name. Defaults to None.
+
+    Attributes:
+        file_id: the ID of the file previously uploaded to OpenAI.
+        organization: the OpenAI organization name.
+        info: the information of the file.
+
+    Examples:
+        >>> from opentrain import Dataset
+        >>> dataset = Dataset(file_id="file-1234")
+        >>> dataset.info
+        >>> content = dataset.download()
+        >>> dataset.delete()
+    """
+
     def __init__(self, file_id: str, organization: Union[str, None] = None) -> None:
+        """Initializes the `Dataset` class.
+
+        Args:
+            file_id: the ID of the file previously uploaded to OpenAI.
+            organization: the OpenAI organization name. Defaults to None.
+        """
         self.file_id = file_id
         self.organization = organization
 
     @cached_property
     def info(self) -> Dict[str, Any]:
+        """Returns the information of the file uploaded to OpenAI.
+
+        Returns:
+            A dictionary with the information of the file.
+        """
         return openai.File.retrieve(id=self.file_id, organization=self.organization)
 
     def download(self) -> bytes:
+        """Downloads the file from OpenAI.
+
+        Returns:
+            The content of the file as bytes.
+        """
         warnings.warn(
             "Dataset.download() is just available for paid/pro accounts, so bear in"
             " mind that this will fail if you're using a free tier.",
@@ -30,12 +66,18 @@ class Dataset:
         return openai.File.download(id=self.file_id, organization=self.organization)
 
     def to_file(self, output_path: str) -> None:
+        """Downloads the file from OpenAI and saves it to the specified path.
+
+        Args:
+            output_path: the path where the file will be saved.
+        """
         content = self.download()
         with open(output_path, "wb") as f:
             f.write(content)
         del content
 
     def delete(self) -> None:
+        """Deletes the file from OpenAI."""
         file_deleted = False
         while file_deleted is False:
             try:
@@ -53,6 +95,16 @@ class Dataset:
         file_name: Union[str, None] = None,
         organization: Union[str, None] = None,
     ) -> "Dataset":
+        """Uploads a file to OpenAI and returns a `Dataset` object.
+
+        Args:
+            file_path: the path of the file to be uploaded.
+            file_name: the name of the file to be defined in OpenAI. Defaults to None.
+            organization: the OpenAI organization name. Defaults to None.
+
+        Returns:
+            A `Dataset` object.
+        """
         upload_response = openai.File.create(
             file=open(file_path, "rb"),
             organization=organization,
@@ -68,6 +120,18 @@ class Dataset:
         file_name: Union[str, None] = None,
         organization: Union[str, None] = None,
     ) -> "Dataset":
+        """Uploads a list of records to OpenAI and returns a `Dataset` object. Note
+        that this function saves it first to a local file and then uploads it to
+        OpenAI.
+
+        Args:
+            records: a list of dictionaries with the records to be uploaded.
+            file_name: the name of the file to be defined in OpenAI. Defaults to None.
+            organization: the OpenAI organization name. Defaults to None.
+
+        Returns:
+            A `Dataset` object.
+        """
         local_path = (
             Path.home() / ".cache" / "opentrain" / f"{file_name or uuid4()}.jsonl"
         )
@@ -99,10 +163,21 @@ class Dataset:
 
 
 class File(Dataset):
+    """This class is just a wrapper around Dataset with the same functionality. It's
+    just here to keep the same naming convention as OpenAI."""
+
     pass
 
 
 def list_datasets(organization: Union[str, None] = None) -> List[Dataset]:
+    """Lists the datasets uploaded to your OpenAI or your organization's account.
+
+    Args:
+        organization: the OpenAI organization name. Defaults to None.
+
+    Returns:
+        A list of `Dataset` objects.
+    """
     return [
         Dataset(file_id=file["id"], organization=organization)
         for file in openai.File.list(organization=organization)["data"]
@@ -110,6 +185,15 @@ def list_datasets(organization: Union[str, None] = None) -> List[Dataset]:
 
 
 def list_files(organization: Union[str, None] = None) -> List[File]:
+    """This function is just a wrapper around list_datasets with the same
+    functionality. It's just here to keep the same naming convention as OpenAI.
+
+    Args:
+        organization: the OpenAI organization name. Defaults to None.
+
+    Returns:
+        A list of `File` objects.
+    """
     return [
         File(file_id=file["id"], organization=organization)
         for file in openai.File.list(organization=organization)["data"]

--- a/src/opentrain/dataset.py
+++ b/src/opentrain/dataset.py
@@ -2,6 +2,7 @@ import json
 import warnings
 from functools import cached_property
 from pathlib import Path
+from time import sleep
 from typing import Any, Dict, List, Union
 from uuid import uuid4
 
@@ -34,14 +35,16 @@ class Dataset:
             f.write(content)
         del content
 
-    def delete(self) -> bool:
-        try:
-            openai.File.delete(
-                sid=self.file_id, organization=self.organization, request_timeout=30
-            )
-            return True
-        except TryAgain:
-            return False
+    def delete(self) -> None:
+        file_deleted = False
+        while file_deleted is False:
+            try:
+                openai.File.delete(
+                    sid=self.file_id, organization=self.organization, request_timeout=10
+                )
+                file_deleted = True
+            except TryAgain:
+                sleep(1)
 
     @classmethod
     def from_file(

--- a/src/opentrain/dataset.py
+++ b/src/opentrain/dataset.py
@@ -1,0 +1,111 @@
+import json
+import warnings
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Dict, List, Union
+from uuid import uuid4
+
+import openai
+from openai.error import TryAgain
+
+FILE_SIZE_WARNING = 500 * 1024 * 1024
+
+
+class Dataset:
+    def __init__(self, file_id: str, organization: Union[str, None] = None) -> None:
+        self.file_id = file_id
+        self.organization = organization
+
+    @cached_property
+    def info(self) -> Dict[str, Any]:
+        return openai.File.retrieve(id=self.file_id, organization=self.organization)
+
+    def download(self) -> bytes:
+        warnings.warn(
+            "Dataset.download() is just available for paid/pro accounts, so bear in"
+            " mind that this will fail if you're using a free tier.",
+            stacklevel=2,
+        )
+        return openai.File.download(id=self.file_id, organization=self.organization)
+
+    def to_file(self, output_path: str) -> None:
+        with open(output_path, "wb") as f:
+            f.write(self.download())
+
+    def delete(self) -> bool:
+        try:
+            openai.File.delete(
+                sid=self.file_id, organization=self.organization, request_timeout=30
+            )
+            return True
+        except TryAgain:
+            return False
+
+    @classmethod
+    def from_file(
+        cls,
+        file_path: str,
+        file_name: Union[str, None] = None,
+        organization: Union[str, None] = None,
+    ) -> "Dataset":
+        upload_response = openai.File.create(
+            file=open(file_path, "rb"),
+            organization=organization,
+            purpose="fine-tune",
+            user_provided_filename=file_name,
+        )
+        return cls(file_id=upload_response.id, organization=organization)
+
+    @classmethod
+    def from_records(
+        cls,
+        records: List[Dict[str, str]],
+        file_name: Union[str, None] = None,
+        organization: Union[str, None] = None,
+    ) -> "Dataset":
+        local_path = (
+            Path.home() / ".cache" / "opentrain" / f"{file_name or uuid4()}.jsonl"
+        )
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(local_path.as_posix(), "w") as f:
+            for record in records:
+                json.dump(record, f)
+                f.write("\n")
+
+        if local_path.stat().st_size > FILE_SIZE_WARNING:
+            warnings.warn(
+                f"Your file is larger than {FILE_SIZE_WARNING / 1024 / 1024} MB, and"
+                " the maximum total upload file size in OpenAI is 1GB, so please be"
+                " aware that if you already have uploaded files to OpenAI this might"
+                " fail. If you need to upload larger files or require more space,"
+                " please contact OpenAI as suggested at"
+                " https://platform.openai.com/docs/api-reference/files/upload.",
+                stacklevel=2,
+            )
+
+        upload_response = openai.File.create(
+            file=open(local_path.as_posix(), "rb"),
+            organization=organization,
+            purpose="fine-tune",
+            user_provided_filename=file_name,
+        )
+        return cls(file_id=upload_response.id, organization=organization)
+
+
+class File(Dataset):
+    pass
+
+
+def list_datasets(organization: Union[str, None] = None) -> List[Dataset]:
+    return [
+        Dataset(file_id=file.id, organization=organization)
+        for file in openai.File.list(organization=organization)
+    ]
+
+
+def list_files(organization: Union[str, None] = None) -> List[File]:
+    return [
+        File(file_id=file.id, organization=organization)
+        for file in openai.File.list(organization=organization)
+    ]

--- a/src/opentrain/dataset.py
+++ b/src/opentrain/dataset.py
@@ -29,8 +29,10 @@ class Dataset:
         return openai.File.download(id=self.file_id, organization=self.organization)
 
     def to_file(self, output_path: str) -> None:
+        content = self.download()
         with open(output_path, "wb") as f:
-            f.write(self.download())
+            f.write(content)
+        del content
 
     def delete(self) -> bool:
         try:

--- a/src/opentrain/dataset.py
+++ b/src/opentrain/dataset.py
@@ -104,13 +104,13 @@ class File(Dataset):
 
 def list_datasets(organization: Union[str, None] = None) -> List[Dataset]:
     return [
-        Dataset(file_id=file.id, organization=organization)
-        for file in openai.File.list(organization=organization)
+        Dataset(file_id=file["id"], organization=organization)
+        for file in openai.File.list(organization=organization)["data"]
     ]
 
 
 def list_files(organization: Union[str, None] = None) -> List[File]:
     return [
-        File(file_id=file.id, organization=organization)
-        for file in openai.File.list(organization=organization)
+        File(file_id=file["id"], organization=organization)
+        for file in openai.File.list(organization=organization)["data"]
     ]

--- a/src/opentrain/typing.py
+++ b/src/opentrain/typing.py
@@ -1,0 +1,5 @@
+from typing import Dict, Union
+
+from opentrain.dataset import Dataset, File
+
+DatasetType = Union[Dataset, Dict[str, Dataset], File, Dict[str, File]]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,51 @@
+import json
+import tempfile
+
+import pytest
+
+from opentrain.dataset import Dataset
+
+
+class TestDatasetFromRecords:
+    @pytest.fixture(autouse=True)
+    @pytest.mark.usefixtures("training_data")
+    def setup_method(self, training_data: list) -> None:
+        self.dataset = Dataset.from_records(
+            records=training_data, file_name="opentrain-test-dataset"
+        )
+
+    def teardown_method(self) -> None:
+        self.dataset.delete()
+        del self.dataset
+
+    def test_info(self) -> None:
+        info = self.dataset.info
+        assert isinstance(info, dict)
+        assert info["id"] == self.dataset.file_id
+        assert info["object"] == "file"
+        assert info["purpose"] == "fine-tune"
+
+
+class TestDatasetFromFile:
+    @pytest.fixture(autouse=True)
+    @pytest.mark.usefixtures("training_data")
+    def setup_method(self, training_data: dict) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".jsonl") as f:
+            with open(f.name, "w") as f:
+                for record in training_data:
+                    json.dump(record, f)
+                    f.write("\n")
+            self.dataset = Dataset.from_file(
+                file_path=f.name, file_name="opentrain-test-dataset"
+            )
+
+    def teardown_method(self) -> None:
+        self.dataset.delete()
+        del self.dataset
+
+    def test_info(self) -> None:
+        info = self.dataset.info
+        assert isinstance(info, dict)
+        assert info["id"] == self.dataset.file_id
+        assert info["object"] == "file"
+        assert info["purpose"] == "fine-tune"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from opentrain.dataset import Dataset
+from opentrain.dataset import Dataset, list_datasets
 
 
 class TestDatasetFromRecords:
@@ -49,3 +49,10 @@ class TestDatasetFromFile:
         assert info["id"] == self.dataset.file_id
         assert info["object"] == "file"
         assert info["purpose"] == "fine-tune"
+
+
+def test_list_datasets() -> None:
+    datasets = list_datasets()
+    assert isinstance(datasets, list)
+    assert len(datasets) > 0
+    assert isinstance(datasets[0], Dataset)


### PR DESCRIPTION
## ✨ Features

- Add `Dataset` class with the property `info` to get some information about it from OpenAI, and the methods `download` and `delete` to either download or delete the file from OpenAI, respectively; and, finally, the class methods `from_file` and `from_records` to create the file either from a list of Python dictionaries or from a JSONL file, respectively.
- Additionally, `File` has been included as a placeholder for `Dataset` with the exact same functionality, just to be fully aligned with OpenAI naming convention.
- Add `list_datasets` and `list_files` functions
- Add every class and function defined in `opentrain.dataset` in `__all__` to import those as e.g. `from opentrain import Dataset` instead of `from opentrain.dataset import Dataset`

## ➖ Minor

- Switch the order in which `ruff` and `black` are executed, so that code-formatting goes before linting, for readability when trying to solve the linting issues

## 🧪 Tests

- [X] Add unit tests for `Datasets` and `list_datasets`